### PR TITLE
Bugfix open deprecation

### DIFF
--- a/lib/facter/digital_ocean.rb
+++ b/lib/facter/digital_ocean.rb
@@ -10,7 +10,7 @@ require 'open-uri'
 require 'timeout'
 
 def metadata(id = "")
-  open("http://169.254.169.254/metadata/v1/#{id||=''}").read.
+  URI.open("http://169.254.169.254/metadata/v1/#{id||=''}").read.
     split("\n").each do |o|
     key = "#{id}#{o.gsub(/\=.*$/, '/')}"
     if key[-1..-1] != '/'
@@ -27,7 +27,7 @@ def metadata(id = "")
       end
 
       # Fetch the data.
-      value = open("http://169.254.169.254/metadata/v1/#{key}").read.
+      value = URI.open("http://169.254.169.254/metadata/v1/#{key}").read.
         split("\n")
       value = value.size>1 ? value : value.first
       symbol = "digital_ocean_#{key.gsub(/\-|\//, '_')}".to_sym
@@ -37,7 +37,7 @@ def metadata(id = "")
     else
       if key == 'tags/'
         # Fetch tags as a single array.
-        value = open("http://169.254.169.254/metadata/v1/tags").read.split("\n")
+        value = URI.open("http://169.254.169.254/metadata/v1/tags").read.split("\n")
         symbol = "digital_ocean_tags".to_sym
         Facter.add(symbol) { setcode { value } }
       else

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jethrocarr-digitalocean",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "jethrocarr",
   "summary": "Small Puppet fact to expose metadata for Digital Ocean virtual machines",
   "license": "Apache 2.0",


### PR DESCRIPTION
open() calls now trigger a deprecation warning.
https://bugs.ruby-lang.org/issues/15893

I've simply changed the open() calls to URI.open() which fixes the issue.